### PR TITLE
Change input report processing/reader threads to daemons

### DIFF
--- a/pywinusb/hid/core.py
+++ b/pywinusb/hid/core.py
@@ -867,6 +867,7 @@ class HidDevice(HidDeviceBaseClass):
             threading.Thread.__init__(self)
             self.__abort = False
             self.hid_object = hid_object
+            self.daemon = True
             self.start()
 
         def abort(self):
@@ -900,6 +901,7 @@ class HidDevice(HidDeviceBaseClass):
             if hid_object and hid_handle and self.raw_report_size \
                     and self.report_queue:
                 #only if input reports are available
+                self.daemon = True
                 self.start()
             else:
                 hid_object.close()


### PR DESCRIPTION
While developing a Python app which uses PyWinUSB, I am frequently running into cases while debugging (my code) where the main thread exits due to an exception, but a HID device is already open and there is a thread running in the background which prevents the process from terminating. There is a simple change for threads which causes them to automatically close when the main thread closes, and that is to set the `.daemon` member variable to `True` prior to calling `start()` on the thread. I tried applying this modification in the two relevant places in `core.py`, and it seems to have solved the problem nicely.

If there is any reason why you intentionally did _not_ do this, please feel free to reject the request...but otherwise it might be a helpful addition.
