### PR TITLE
Suppress pylint import-error in python 3

### DIFF
--- a/pywinusb/hid/helpers.py
+++ b/pywinusb/hid/helpers.py
@@ -6,11 +6,10 @@ from __future__ import print_function
 
 import sys
 if sys.version_info >= (3,):
-    # pylint: disable=no-name-in-module
-    from collections import UserList
+    from collections import UserList  # pylint: disable=no-name-in-module
 else:
     # python 2
-    from UserList import UserList
+    from UserList import UserList  # pylint: disable=import-error
 
 class HIDError(Exception):
     "Main HID error exception class type"


### PR DESCRIPTION
Add the directive "# pylint: disable=import-error" to disable the
the pylint error when running under python 3.

Note:
pylint 1.4.4 + astroid 1.3.8 did not give this import error. The error
started sometime after and can be seen in pylint 1.5.4 + astroid 1.4.4.