### PR TITLE
Fix intermittent lockup on close

### DIFF
--- a/pywinusb/hid/core.py
+++ b/pywinusb/hid/core.py
@@ -931,15 +931,15 @@ class HidDevice(HidDeviceBaseClass):
         def abort(self):
             """Stop collectiong reports."""
             with self.__abort_lock:
-                if not self.__abort and self.__h_read_event:
-                    # force overlapped events competition
-
+                if not self.__abort:
                     # The abort variable must be set to true
                     # before sending the event, otherwise
                     # the reader thread might skip
                     # CancelIo
                     self.__abort = True
-                    winapi.SetEvent(self.__h_read_event)
+                    if self.__h_read_event:
+                        # force overlapped events competition
+                        winapi.SetEvent(self.__h_read_event)
 
         def is_active(self):
             "main reading loop is running (bool)"


### PR DESCRIPTION
When aborting execution of the input reader thread set "__abort" to true, even if __h_read_event is null. This prevents a race condition which occurs if abort is called before the input reader thread has created its read event. If this race condition occurs then __abort will not get set to true and the input reader thread will not terminate. This causes close() to get stuck when trying to join this thread.
