### PR TITLE
Fix for passing c_ubyte array as a raw_data

### DIFF
--- a/pywinusb/hid/core.py
+++ b/pywinusb/hid/core.py
@@ -1489,8 +1489,8 @@ class HidReport(object):
                 issubclass(raw_data._type_, c_ubyte) ):
             # pre-memory allocation for performance
             self.__alloc_raw_data(raw_data)
-        #reference proper object
-        raw_data = self.__raw_data
+            # reference proper object
+            raw_data = self.__raw_data
         if self.__report_kind == HidP_Output:
             return self.__hid_object.send_output_report(raw_data)
         elif self.__report_kind == HidP_Feature:


### PR DESCRIPTION
When using `HidReport.send(raw_data)`, `c_ubyte` or `ctypes.Array` type should be used to achieve the best performance and avoid copying the data.
However, when actually passing `c_ubyte` array as an argument to the `HidReport.send(raw_data)`, internal `self.__raw_data` is not prepared (`self.__prepare_raw_data()` on 1487) nor allocated (`self.__alloc_raw_data(raw_data)` on 1491) as both conditions are `False`. Despite of that, `raw_data` is then overwritten with uninitialised `__raw_data` and then passed to `self.__hid_object.send_output_report(raw_data)` which throws `TypeError: object of type 'NoneType' has no len()`.