### PR TITLE
Fixes off-by-one when looping over a Usage range.

### DIFF
--- a/pywinusb/hid/core.py
+++ b/pywinusb/hid/core.py
@@ -1222,7 +1222,7 @@ class HidReport(object):
                         self.__value_array_items.append(report_item)
                 else:
                     for usage_id in range(item.usage_min,
-                            item.usage_max):
+                            item.usage_max+1):
                         report_item =  ReportItem(self, item, usage_id)
                         self.__items[report_item.key()] = report_item
                         self.__idx_items[report_item.data_index] = report_item


### PR DESCRIPTION
I found that when finding usages in a report, that usage ranges were incorrectly reported.  Given the descriptor below one less usage is reported than should be:

```
    0xa1, 0x02,       //     COLLECTION (Logical)
    0x05, 0x0a,       //     USAGE_PAGE (Ordinal)
    0x19, 0x01,       //     USAGE_MINIMUM (1)
    0x29, 0x08,       //     USAGE_MAXIMUM (8)
    0x05, 0x08,       //     USAGE_PAGE (LED)
    0x19, 0x4b,       //     USAGE_MINIMUM (Generic Indicator)
    0x29, 0x4b,       //     USAGE_MAXIMUM (Generic Indicator)
    0x95, 0x08,       //     REPORT_COUNT (8)
    0x75, 0x01,       //     REPORT_SIZE (1)
    0x15, 0x00,       //     LOGICAL_MINIMUM (0)
    0x25, 0x01,       //     LOGICAL_MAXIMUM (1)
    0x91, 0x02,       //     OUTPUT (Data, Var, Abs)
    0xc0,             //     END_COLLECTION (Logical)
```

Then, for example, using pywinusb:

```
>>> from pywinusb import hid
>>> device = hid.find_all_hid_devices()[-1]
>>> device.open()
>>> report = device.find_output_reports()[0]
>>> report
HID report object (Output report, id=0x0a), 7 items included
```

Investigating, I found that the usages are iterated using `range()` which goes from the minimum inclusive to the maximum _exclusive_ while HID Usage Minimum is inclusive and Usage Maximum is also _inclusive_.

This PR adds one to the max to ensure that python `range()` generates the complete list of usage_ids.