### PR TITLE
core.py update to avoid AttributeError

### DIFF
--- a/pywinusb/hid/core.py
+++ b/pywinusb/hid/core.py
@@ -14,6 +14,7 @@ import threading
 import collections
 if sys.version_info >= (3,):
     import winreg
+    collections.Callable = collections.abc.Callable
 else:
     import _winreg as winreg
 


### PR DESCRIPTION
Updated [core.py](https://github.com/rene-aguirre/pywinusb/blob/master/pywinusb/hid/core.py) to avoid
AttributeError: module 'collections' has no attribute 'Callable'
when running [show_hids.py](https://github.com/rene-aguirre/pywinusb/blob/master/examples/show_hids.py) example with python 3.10
